### PR TITLE
Overview updates

### DIFF
--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -21,6 +21,7 @@ const {
   createAddress,
   createAccount,
   getxpubCreateWatchOnly,
+  getAccountHistory,
 } = require('./account');
 
 const { addSideNav } = require('./interface');
@@ -32,6 +33,7 @@ module.exports = {
   addSideNav,
   joinWallet,
   updateTextField,
+  getAccountHistory,
   getWallets,
   getWalletsInfo,
   getWalletInfo,

--- a/lib/components/BoxGrid.js
+++ b/lib/components/BoxGrid.js
@@ -19,6 +19,7 @@ class BoxGrid extends PureComponent {
       ]),
       onClick: PropTypes.func,
       theme: PropTypes.object,
+      childrenClass: PropTypes.string,
     };
   }
 
@@ -35,7 +36,7 @@ class BoxGrid extends PureComponent {
   }
 
   render() {
-    const { children, theme, colcount, rowClass, colClass } = this.props;
+    const { children, theme, colcount, rowClass, colClass, childrenClass } = this.props;
 
     // handle case when only a single child
     const childElements = React.Children.toArray(children);
@@ -44,10 +45,11 @@ class BoxGrid extends PureComponent {
     return chunks.map((chunk, i) => {
       return (
         <div key={i} className={`row ${rowClass} ${theme.box}`}>
-          {chunk.map((el, j) => {
+          {chunk.map((Child, j) => {
             return (
               <div key={j} className={`col ${colClass}`}>
-                {el}
+                {/* only clone the react element if childrenClass prop is present */}
+                {childrenClass ? React.cloneElement(Child, { className: childrenClass }) : Child}
               </div>
             );
           })}

--- a/lib/components/BoxGrid.js
+++ b/lib/components/BoxGrid.js
@@ -36,7 +36,14 @@ class BoxGrid extends PureComponent {
   }
 
   render() {
-    const { children, theme, colcount, rowClass, colClass, childrenClass } = this.props;
+    const {
+      children,
+      theme,
+      colcount,
+      rowClass,
+      colClass,
+      childrenClass,
+    } = this.props;
 
     // handle case when only a single child
     const childElements = React.Children.toArray(children);
@@ -49,7 +56,9 @@ class BoxGrid extends PureComponent {
             return (
               <div key={j} className={`col ${colClass}`}>
                 {/* only clone the react element if childrenClass prop is present */}
-                {childrenClass ? React.cloneElement(Child, { className: childrenClass }) : Child}
+                {childrenClass
+                  ? React.cloneElement(Child, { className: childrenClass })
+                  : Child}
               </div>
             );
           })}

--- a/lib/components/List.js
+++ b/lib/components/List.js
@@ -33,15 +33,14 @@ class List extends PureComponent {
   render() {
     const { data, text, headers, type } = this.props;
     let render;
-    if (type === 'transaction') render = <TransactionTable transactions={data} />;
+    if (type === 'transaction')
+      render = <TransactionTable transactions={data} />;
     else render = <Table colHeaders={headers} tableData={data} />;
 
     return (
       <BoxGrid childrenClass="p-2">
         <Header type="h2">{text}</Header>
-        <div>
-          {render}
-        </div>
+        <div>{render}</div>
       </BoxGrid>
     );
   }

--- a/lib/components/List.js
+++ b/lib/components/List.js
@@ -33,13 +33,13 @@ class List extends PureComponent {
   render() {
     const { data, text, headers, type } = this.props;
     let render;
-    if (type === 'transaction') render = <TransactionTable />;
+    if (type === 'transaction') render = <TransactionTable transactions={data} />;
     else render = <Table colHeaders={headers} tableData={data} />;
 
     return (
-      <BoxGrid>
+      <BoxGrid childrenClass="p-2">
+        <Header type="h2">{text}</Header>
         <div>
-          <Header type="h5">{text}</Header>
           {render}
         </div>
       </BoxGrid>

--- a/lib/constants/bwallet.js
+++ b/lib/constants/bwallet.js
@@ -14,7 +14,7 @@ export const OVERVIEW_LIST_HEADERS = [
   'Name',
   'Balance',
   'Watch Only',
-  'Multi-Sig',
+  'Multi-Party',
 ];
 export const OVERVIEW_MP_LIST_HEADERS = ['Name', 'Date', 'M of N', 'Init'];
 

--- a/lib/containers/Overview.js
+++ b/lib/containers/Overview.js
@@ -58,7 +58,11 @@ class Overview extends PureComponent {
           headers={OVERVIEW_MP_LIST_HEADERS}
           data={pendingMultiparty}
         />
-        <List text="Recent Transaction List" type="transaction" data={recentTransactions} />
+        <List
+          text="Recent Transaction List"
+          type="transaction"
+          data={recentTransactions}
+        />
       </div>
     );
   }

--- a/lib/containers/Overview.js
+++ b/lib/containers/Overview.js
@@ -18,6 +18,7 @@ class Overview extends PureComponent {
       wallets: PropTypes.array,
       walletsList: PropTypes.array,
       pendingMultiparty: PropTypes.array,
+      recentTransactions: PropTypes.array,
     };
   }
 
@@ -26,6 +27,7 @@ class Overview extends PureComponent {
       wallets: [],
       walletsList: [],
       pendingMultiparty: [],
+      recentTransactions: [],
     };
   }
 
@@ -43,9 +45,9 @@ class Overview extends PureComponent {
   }
 
   render() {
-    const { walletsList, pendingMultiparty } = this.props;
+    const { walletsList, pendingMultiparty, recentTransactions } = this.props;
     return (
-      <div>
+      <div className="container">
         <List
           text="Overview"
           headers={OVERVIEW_LIST_HEADERS}
@@ -56,7 +58,7 @@ class Overview extends PureComponent {
           headers={OVERVIEW_MP_LIST_HEADERS}
           data={pendingMultiparty}
         />
-        <List text="Recent Transaction List" type="transaction" />
+        <List text="Recent Transaction List" type="transaction" data={recentTransactions} />
       </div>
     );
   }

--- a/lib/containers/SendReceive.js
+++ b/lib/containers/SendReceive.js
@@ -10,7 +10,7 @@ import {
   JoinWallet,
   CreateProposal,
   ApproveReject,
-} from '../Components';
+} from '../components';
 
 import { isEqual } from 'lodash';
 import { sendReceive } from '../mappings';

--- a/lib/mappings/overview.js
+++ b/lib/mappings/overview.js
@@ -29,7 +29,9 @@ function buildWalletsList(wallets, multisigWallets, chain) {
   for (const msWallet of Object.values(multisigWallets)) {
     walletsList.push({
       Name: msWallet.id || '',
-      Balance: new Currency(chain, msWallet.balance.confirmed).withLabel('unit'),
+      Balance: new Currency(chain, msWallet.balance.confirmed).withLabel(
+        'unit'
+      ),
       'Watch Only': 'true', // are multisig wallets watch only?
       'Multi-Party': 'true',
     });
@@ -71,10 +73,12 @@ function mapStateToProps(state, otherProps) {
   const recentTransactions = [];
   for (const [key, w] of Object.entries(history)) {
     if (w.default)
-      recentTransactions.push(...w.default.slice(0,10).map(tx => {
-        tx.wallet = key;
-        return tx;
-      }));
+      recentTransactions.push(
+        ...w.default.slice(0, 10).map(tx => {
+          tx.wallet = key;
+          return tx;
+        })
+      );
   }
 
   return {
@@ -93,7 +97,8 @@ function mapDispatchToProps(dispatch) {
   return {
     getWallets: type => dispatch(getWallets(type)),
     getWalletInfo: (walletId, type) => dispatch(getWalletInfo(walletId, type)),
-    getAccountHistory: (walletId, accountId) => dispatch(getAccountHistory(walletId, accountId)),
+    getAccountHistory: (walletId, accountId) =>
+      dispatch(getAccountHistory(walletId, accountId)),
   };
 }
 

--- a/lib/mappings/overview.js
+++ b/lib/mappings/overview.js
@@ -1,33 +1,37 @@
-import { getWallets, getWalletInfo } from '../actions';
+import { getWallets, getWalletInfo, getAccountHistory } from '../actions';
 import assert from 'bsert';
+import { Currency } from '@bpanel/bpanel-utils';
 
 import {
   selectWallets,
   selectMultisigWallets,
   selectWalletInfo,
   selectMultisigWalletInfo,
+  selectHistory,
+  selectCurrentChain,
 } from './selectors';
 
-// TODO: append proper network symbol to balance based on chain
-function buildWalletsList(wallets, multisigWallets) {
+function buildWalletsList(wallets, multisigWallets, chain) {
   assert(wallets, 'must provide wallets object');
   assert(multisigWallets, 'must provide multisigwallets object');
 
+  // the keys of each object correspond to constants/bwallet.js
+  // OVERVIEW_LIST_HEADERS
   const walletsList = [];
   for (const wallet of Object.values(wallets)) {
     walletsList.push({
       Name: wallet.id || '',
-      Balance: wallet.balance.confirmed,
-      'Watch Only': wallet.watchOnly,
-      Multisig: false,
+      Balance: new Currency(chain, wallet.balance.confirmed).withLabel('unit'),
+      'Watch Only': `${wallet.watchOnly}`,
+      'Multi-Party': 'false',
     });
   }
   for (const msWallet of Object.values(multisigWallets)) {
     walletsList.push({
       Name: msWallet.id || '',
-      Balance: msWallet.balance.confirmed,
-      'Watch Only': msWallet.watchOnly,
-      Multisig: true,
+      Balance: new Currency(chain, msWallet.balance.confirmed).withLabel('unit'),
+      'Watch Only': 'true', // are multisig wallets watch only?
+      'Multi-Party': 'true',
     });
   }
 
@@ -39,9 +43,12 @@ function buildWalletsList(wallets, multisigWallets) {
 function buildPendingMSList(multisigWallets) {
   const wallets = [];
   for (const wallet of Object.values(multisigWallets)) {
-    if (wallet.pending)
+    if (wallet.initialized === false)
       wallets.push({
-        name: wallet.id || '',
+        Name: wallet.id || '',
+        Date: 'TODO', // can implement with new version of bmultisig
+        'M of N': `${wallet.m} of ${wallet.n}`,
+        Init: `${wallet.initialized}`,
       });
   }
   return wallets;
@@ -52,9 +59,23 @@ function mapStateToProps(state, otherProps) {
   const multisigWallets = selectMultisigWallets(state);
   const walletInfo = selectWalletInfo(state);
   const multisigWalletInfo = selectMultisigWalletInfo(state);
+  const chain = selectCurrentChain(state);
 
-  const walletsList = buildWalletsList(walletInfo, multisigWalletInfo);
+  const walletsList = buildWalletsList(walletInfo, multisigWalletInfo, chain);
   const pendingMultiparty = buildPendingMSList(multisigWalletInfo);
+  const history = selectHistory(state);
+
+  // TODO: come up with better strategy for rendering transactions
+  // for now render the first 10 transactions for each wallet's
+  // default account
+  const recentTransactions = [];
+  for (const [key, w] of Object.entries(history)) {
+    if (w.default)
+      recentTransactions.push(...w.default.slice(0,10).map(tx => {
+        tx.wallet = key;
+        return tx;
+      }));
+  }
 
   return {
     wallets,
@@ -63,6 +84,7 @@ function mapStateToProps(state, otherProps) {
     multisigWalletInfo,
     walletsList,
     pendingMultiparty,
+    recentTransactions,
     ...otherProps,
   };
 }
@@ -71,6 +93,7 @@ function mapDispatchToProps(dispatch) {
   return {
     getWallets: type => dispatch(getWallets(type)),
     getWalletInfo: (walletId, type) => dispatch(getWalletInfo(walletId, type)),
+    getAccountHistory: (walletId, accountId) => dispatch(getAccountHistory(walletId, accountId)),
   };
 }
 


### PR DESCRIPTION
- [x] render data in overview tables
- [x] style overview page
- [x] fix casing import bug
- [x] add `childrenClass` prop to `BoxGrid`

Its really difficult to query all of the transactions to fill the recent transactions table.
On a node with moderate usage, it will cause some mega pain, unless we index the transactions
outside of bcoin. Buck and I were thinking a bit about what we can do if we were to replace that
table with something else. The overview page should give people a useful overview of their wallets

Things like:

- Number of transactions per wallet
- Number of utxos per wallet
- Average utxo size
- Current fee
- Mempool size
- Latest block hash (so you know you aren't being eclipsed)
- Number of peers (so you can feel confident you can't be eclipsed)
- rescan from block height

Open to more ideas