### PR TITLE
Rename xpub to hd public key

### DIFF
--- a/lib/components/CreateAccount.js
+++ b/lib/components/CreateAccount.js
@@ -55,8 +55,8 @@ class CreateAccount extends PureComponent {
     return (
       <BoxGrid rowClass="d-inline-flex">
         <ViewButton
-          header={'xpub'}
-          text={'Enter an xpub to import'}
+          header="HD Public Key"
+          text="Enter a HD Public Key to import"
           onClick={() => this.update('view', 'xpub')}
         />
         <ViewButton
@@ -92,11 +92,11 @@ class CreateAccount extends PureComponent {
             type="password"
           />
         </Label>
-        <Label className="d-flex align-items-start" text="xpub">
+        <Label className="d-flex align-items-start" text="HD Public Key">
           <Input
             name="xpub"
             className="col"
-            placeholder="xpub"
+            placeholder="HD Public Key"
             onChange={e => this.update('xpub', e.target.value)}
             value={xpub}
           />

--- a/lib/components/CreateAccount.js
+++ b/lib/components/CreateAccount.js
@@ -55,13 +55,13 @@ class CreateAccount extends PureComponent {
     return (
       <BoxGrid rowClass="d-inline-flex">
         <ViewButton
-          header="HD Public Key"
-          text="Enter a HD Public Key to import"
+          header="Extended Public Key"
+          text="Enter an Extended Public Key to import"
           onClick={() => this.update('view', 'xpub')}
         />
         <ViewButton
-          header={'Hardware'}
-          text={'Import an account from hardware.'}
+          header="Hardware"
+          text="Import an account from hardware."
           onClick={() => this.update('view', 'hardware')}
         />
       </BoxGrid>
@@ -92,11 +92,11 @@ class CreateAccount extends PureComponent {
             type="password"
           />
         </Label>
-        <Label className="d-flex align-items-start" text="HD Public Key">
+        <Label className="d-flex align-items-start" text="Extended Public Key">
           <Input
             name="xpub"
             className="col"
-            placeholder="HD Public Key"
+            placeholder="Extended Public Key"
             onChange={e => this.update('xpub', e.target.value)}
             value={xpub}
           />

--- a/lib/components/ViewButton.js
+++ b/lib/components/ViewButton.js
@@ -35,7 +35,7 @@ class ViewButton extends PureComponent {
         style={containerStyle}
         onClick={onClick}
       >
-        <Header style={style.text} type="h1">
+        <Header style={style.text} type="h2">
           {this.props.header}
         </Header>
         <Text style={style.text} type="p">

--- a/lib/components/WatchOnly.js
+++ b/lib/components/WatchOnly.js
@@ -65,7 +65,9 @@ class WatchOnly extends PureComponent {
         </BoxGrid>
         <BoxGrid rowClass="d-inline" colcount={1}>
           <Header type="h4">Watch Only Wallet</Header>
-          <Text type="p">Upload a HD Public Key and trigger a chain rescan</Text>
+          <Text type="p">
+            Upload a HD Public Key and trigger a chain rescan
+          </Text>
           <Button onClick={() => this.create(newWalletName, xpub)}>
             Import
           </Button>

--- a/lib/components/WatchOnly.js
+++ b/lib/components/WatchOnly.js
@@ -53,11 +53,11 @@ class WatchOnly extends PureComponent {
               value={newWalletName}
             />
           </Label>
-          <Label className="d-flex align-items-start" text="xpub">
+          <Label className="d-flex align-items-start" text="HD Public Key">
             <Input
               name="xpub"
               className="col"
-              placeholder="xpub"
+              placeholder="HD Public Key"
               onChange={e => this.input('xpub', e.target.value)}
               value={xpub}
             />
@@ -65,7 +65,7 @@ class WatchOnly extends PureComponent {
         </BoxGrid>
         <BoxGrid rowClass="d-inline" colcount={1}>
           <Header type="h4">Watch Only Wallet</Header>
-          <Text type="p">Upload an xpub and trigger a chain rescan</Text>
+          <Text type="p">Upload a HD Public Key and trigger a chain rescan</Text>
           <Button onClick={() => this.create(newWalletName, xpub)}>
             Import
           </Button>

--- a/lib/components/WatchOnly.js
+++ b/lib/components/WatchOnly.js
@@ -53,7 +53,10 @@ class WatchOnly extends PureComponent {
               value={newWalletName}
             />
           </Label>
-          <Label className="d-flex align-items-start" text="Extended Public Key">
+          <Label
+            className="d-flex align-items-start"
+            text="Extended Public Key"
+          >
             <Input
               name="xpub"
               className="col"

--- a/lib/components/WatchOnly.js
+++ b/lib/components/WatchOnly.js
@@ -53,11 +53,11 @@ class WatchOnly extends PureComponent {
               value={newWalletName}
             />
           </Label>
-          <Label className="d-flex align-items-start" text="HD Public Key">
+          <Label className="d-flex align-items-start" text="Extended Public Key">
             <Input
               name="xpub"
               className="col"
-              placeholder="HD Public Key"
+              placeholder="Extended Public Key"
               onChange={e => this.input('xpub', e.target.value)}
               value={xpub}
             />
@@ -66,7 +66,7 @@ class WatchOnly extends PureComponent {
         <BoxGrid rowClass="d-inline" colcount={1}>
           <Header type="h4">Watch Only Wallet</Header>
           <Text type="p">
-            Upload a HD Public Key and trigger a chain rescan
+            Upload an Extended Public Key and trigger a chain rescan
           </Text>
           <Button onClick={() => this.create(newWalletName, xpub)}>
             Import

--- a/lib/containers/WalletInfo.js
+++ b/lib/containers/WalletInfo.js
@@ -331,7 +331,7 @@ class WalletInfo extends PureComponent {
                 Average UTXO Size: {selectedAccountAvgUTXOSize}
               </Text>
               <Text type="p">
-                Account HD Public Key:{' '}
+                Account Extended Public Key:{' '}
                 <Text type="condensed">{selectedAccountxpub}</Text>
               </Text>
             </div>

--- a/lib/containers/WalletInfo.js
+++ b/lib/containers/WalletInfo.js
@@ -331,7 +331,7 @@ class WalletInfo extends PureComponent {
                 Average UTXO Size: {selectedAccountAvgUTXOSize}
               </Text>
               <Text type="p">
-                Account Public Key (xpub):{' '}
+                Account HD Public Key:{' '}
                 <Text type="condensed">{selectedAccountxpub}</Text>
               </Text>
             </div>


### PR DESCRIPTION
Basic copy update that renames `xpub` to `HD Public Key` in a few places. I think that `xpub` is more confusing as a term, it is easier to google for `HD Public Key`, plus users can import the pubkey from any path if they so choose, so it is actually a better description