### PR TITLE
View refresh

### DIFF
--- a/lib/containers/WalletInfo.js
+++ b/lib/containers/WalletInfo.js
@@ -21,6 +21,10 @@ class WalletInfo extends PureComponent {
   }
 
   componentDidMount() {
+    this.selectWalletAndAccount();
+  }
+
+  selectWalletAndAccount() {
     const {
       selectWallet,
       selectAccount,
@@ -39,7 +43,7 @@ class WalletInfo extends PureComponent {
 
     // only select wallet if it has yet to be selected
     // this prevents an infinite loop
-    if (selectedWallet !== wallet) {
+    if (!selectedWallet || selectedWallet !== wallet) {
       // fetch detailed proposal information and reset
       // the send/receive tab index to 0
       selectWallet(wallet, type, { proposals: true, resetSendTab: true });
@@ -49,6 +53,15 @@ class WalletInfo extends PureComponent {
     // isn't part of currently selected wallet's accounts
     if (selectedWallet && !accounts.includes(selectedAccount))
       selectAccount(selectedWallet, 'default', true);
+  }
+
+  componentDidUpdate(prevProps) {
+    // need to check if we are on a new WalletInfo path in order
+    // in which case we select a new wallet
+    const {
+      params: { wallet },
+    } = this.props.match;
+    if (wallet !== prevProps.match.params.wallet) this.selectWalletAndAccount();
   }
 
   static get propTypes() {

--- a/lib/mappings/walletInfo.js
+++ b/lib/mappings/walletInfo.js
@@ -160,7 +160,7 @@ function mapStateToProps(state, otherProps) {
 
   let selectedWalletBalance;
   let selectedWalletTransactionCount;
-  if (selectedWalletInfo && selectedWalletInfo.balance) {
+  if (selectedWalletInfo && selectedWalletInfo.balance && chain) {
     const balance = selectedWalletInfo.balance.confirmed || 0;
     selectedWalletBalance = new Currency(chain, balance).withLabel('unit');
     selectedWalletTransactionCount = selectedWalletInfo.balance.tx;


### PR DESCRIPTION
Fixes #55 

Issue turned out to be that since we were no longer remounting the subviews with every change w/ the previous fix, the selectedWallet wasn't being set in the `interface` if you simply changed between `WalletInfo` views. This adds a check on `componentDidUpdate` to see if the `wallet` param updated and to cause a `selectWallet` to occur if so.

Also added a check for `chain` in an action that included `Currency`. This fixes a crash if you reload the page while on a wallet info view.

Steps to reproduce the main problem are in the issue report.